### PR TITLE
Rate limiting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ packages
 /*DotSettings.user
 bin
 test/bin/
+.dev/
+

--- a/InvisibleCollectorLib/Connection/ApiConnectionFacade.cs
+++ b/InvisibleCollectorLib/Connection/ApiConnectionFacade.cs
@@ -15,7 +15,7 @@ namespace InvisibleCollectorLib.Connection
 
     internal class ApiConnectionFacade
     {
-        private const int MaxConcurrentConnections = 10;
+        private const int MaxConcurrentConnections = 90;
 
         private readonly string _apiKey;
         private readonly Func<Stream, IDictionary<string, string>> _jsonParser;

--- a/InvisibleCollectorLib/Connection/ApiConnectionFacade.cs
+++ b/InvisibleCollectorLib/Connection/ApiConnectionFacade.cs
@@ -21,14 +21,15 @@ namespace InvisibleCollectorLib.Connection
         private readonly Func<Stream, IDictionary<string, string>> _jsonParser;
         private readonly HttpClient _client;
 
-        internal ApiConnectionFacade(string apiKey, Func<Stream, IDictionary<string, string>> jsonParser)
+        internal ApiConnectionFacade(string apiKey, Func<Stream, IDictionary<string, string>> jsonParser,
+            int maxConcurrentRequests = IcConstants.MaxConcurrentRequests)
         {
             _apiKey = apiKey;
             _jsonParser = jsonParser;
 
             var handler = new HttpClientHandler
             {
-                MaxConnectionsPerServer = MaxConcurrentConnections
+                MaxConnectionsPerServer = maxConcurrentRequests
             };
             _client = new HttpClient(handler);
         }

--- a/InvisibleCollectorLib/InvisibleCollector.cs
+++ b/InvisibleCollectorLib/InvisibleCollector.cs
@@ -1,8 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
-using System.Threading;
+using System.Net.Http;
 using System.Threading.Tasks;
 using InvisibleCollectorLib.Connection;
 using InvisibleCollectorLib.Exception;
@@ -82,7 +81,7 @@ namespace InvisibleCollectorLib
         ///     On bad json (sent or received) and when the server rejects the request (conflict, bad
         ///     request, invalid parameters, etc)
         /// </exception>
-        /// <exception cref="WebException">
+        /// <exception cref="HttpRequestException">
         ///     On connection or protocol related errors (except for the protocol errors sent by the
         ///     Invisible Collector)
         /// </exception>
@@ -111,7 +110,7 @@ namespace InvisibleCollectorLib
         ///     On bad json (sent or received) and when the server rejects the request (conflict, bad
         ///     request, invalid parameters, etc)
         /// </exception>
-        /// <exception cref="WebException">
+        /// <exception cref="HttpRequestException">
         ///     On connection or protocol related errors (except for the protocol errors sent by the
         ///     Invisible Collector)
         /// </exception>
@@ -140,7 +139,7 @@ namespace InvisibleCollectorLib
         ///     On bad json (sent or received) and when the server rejects the request (conflict, bad
         ///     request, invalid parameters, etc)
         /// </exception>
-        /// <exception cref="WebException">
+        /// <exception cref="HttpRequestException">
         ///     On connection or protocol related errors (except for the protocol errors sent by the
         ///     Invisible Collector)
         /// </exception>
@@ -167,7 +166,7 @@ namespace InvisibleCollectorLib
         ///     On bad json (sent or received) and when the server rejects the request (conflict, bad
         ///     request, invalid parameters, etc)
         /// </exception>
-        /// <exception cref="WebException">
+        /// <exception cref="HttpRequestException">
         ///     On connection or protocol related errors (except for the protocol errors sent by the
         ///     Invisible Collector)
         /// </exception>
@@ -191,7 +190,7 @@ namespace InvisibleCollectorLib
         ///     On bad json (sent or received) and when the server rejects the request (conflict, bad
         ///     request, invalid parameters, etc)
         /// </exception>
-        /// <exception cref="WebException">
+        /// <exception cref="HttpRequestException">
         ///     On connection or protocol related errors (except for the protocol errors sent by the
         ///     Invisible Collector)
         /// </exception>
@@ -220,7 +219,7 @@ namespace InvisibleCollectorLib
         ///     On bad json (sent or received) and when the server rejects the request (conflict, bad
         ///     request, invalid parameters, etc)
         /// </exception>
-        /// <exception cref="WebException">
+        /// <exception cref="HttpRequestException">
         ///     On connection or protocol related errors (except for the protocol errors sent by the
         ///     Invisible Collector)
         /// </exception>
@@ -243,7 +242,7 @@ namespace InvisibleCollectorLib
         ///     On bad json (sent or received) and when the server rejects the request (conflict, bad
         ///     request, invalid parameters, etc)
         /// </exception>
-        /// <exception cref="WebException">
+        /// <exception cref="HttpRequestException">
         ///     On connection or protocol related errors (except for the protocol errors sent by the
         ///     Invisible Collector)
         /// </exception>
@@ -280,7 +279,7 @@ namespace InvisibleCollectorLib
         ///     On bad json (sent or received) and when the server rejects the request (conflict, bad
         ///     request, invalid parameters, etc)
         /// </exception>
-        /// <exception cref="WebException">
+        /// <exception cref="HttpRequestException">
         ///     On connection or protocol related errors (except for the protocol errors sent by the
         ///     Invisible Collector)
         /// </exception>
@@ -311,7 +310,7 @@ namespace InvisibleCollectorLib
         ///     On bad json (sent or received) and when the server rejects the request (conflict, bad
         ///     request, invalid parameters, etc)
         /// </exception>
-        /// <exception cref="WebException">
+        /// <exception cref="HttpRequestException">
         ///     On connection or protocol related errors (except for the protocol errors sent by the
         ///     Invisible Collector)
         /// </exception>
@@ -341,7 +340,7 @@ namespace InvisibleCollectorLib
         ///     On bad json (sent or received) and when the server rejects the request (conflict, bad
         ///     request, invalid parameters, etc)
         /// </exception>
-        /// <exception cref="WebException">
+        /// <exception cref="HttpRequestException">
         ///     On connection or protocol related errors (except for the protocol errors sent by the
         ///     Invisible Collector)
         /// </exception>
@@ -371,7 +370,7 @@ namespace InvisibleCollectorLib
         ///     On bad json (sent or received) and when the server rejects the request (conflict, bad
         ///     request, invalid parameters, etc)
         /// </exception>
-        /// <exception cref="WebException">
+        /// <exception cref="HttpRequestException">
         ///     On connection or protocol related errors (except for the protocol errors sent by the
         ///     Invisible Collector)
         /// </exception>
@@ -409,7 +408,7 @@ namespace InvisibleCollectorLib
         ///     On bad json (received) and when the server rejects the request (conflict, bad
         ///     request, invalid parameters, etc)
         /// </exception>
-        /// <exception cref="WebException">
+        /// <exception cref="HttpRequestException">
         ///     On connection or protocol related errors (except for the protocol errors sent by the
         ///     Invisible Collector)
         /// </exception>
@@ -483,7 +482,7 @@ namespace InvisibleCollectorLib
         ///     On bad json (sent or received) and when the server rejects the request (conflict, bad
         ///     request, invalid parameters, etc)
         /// </exception>
-        /// <exception cref="WebException">
+        /// <exception cref="HttpRequestException">
         ///     On connection or protocol related errors (except for the protocol errors sent by the
         ///     Invisible Collector)
         /// </exception>
@@ -510,7 +509,7 @@ namespace InvisibleCollectorLib
         ///     On bad json (sent or received) and when the server rejects the request (conflict, bad
         ///     request, invalid parameters, etc)
         /// </exception>
-        /// <exception cref="WebException">
+        /// <exception cref="HttpRequestException">
         ///     On connection or protocol related errors (except for the protocol errors sent by the
         ///     Invisible Collector)
         /// </exception>
@@ -535,7 +534,7 @@ namespace InvisibleCollectorLib
         ///     On bad json (sent or received) and when the server rejects the request (conflict, bad
         ///     request, invalid parameters, etc)
         /// </exception>
-        /// <exception cref="WebException">
+        /// <exception cref="HttpRequestException">
         ///     On connection or protocol related errors (except for the protocol errors sent by the
         ///     Invisible Collector)
         /// </exception>
@@ -560,7 +559,7 @@ namespace InvisibleCollectorLib
         ///     On bad json (sent or received) and when the server rejects the request (conflict, bad
         ///     request, invalid parameters, etc)
         /// </exception>
-        /// <exception cref="WebException">
+        /// <exception cref="HttpRequestException">
         ///     On connection or protocol related errors (except for the protocol errors sent by the
         ///     Invisible Collector)
         /// </exception>

--- a/InvisibleCollectorLib/InvisibleCollector.cs
+++ b/InvisibleCollectorLib/InvisibleCollector.cs
@@ -27,7 +27,7 @@ namespace InvisibleCollectorLib
         private const string CustomersEndpoint = "customers";
         private const string DebtsEndpoint = "debts";
         private const string PaymentsEndpoint = "payments";
-        private const string ProdutionUri = "https://api.invisiblecollector.com/";
+        public const string ProductionUri = "https://api.invisiblecollector.com/";
         private readonly ApiConnectionFacade _apiFacade;
         private readonly JsonConvertFacade _jsonFacade;
         private readonly ILogger _logger;
@@ -43,7 +43,7 @@ namespace InvisibleCollectorLib
         /// <param name="remoteUri">The InvisibleCollector service address.</param>
         /// <param name="logger">The logger to be used by the lib</param>
         /// <param name="maxConcurrentRequests">The maximum number of concurrent HTTP requests to InvivisibleCollector</param>
-        public InvisibleCollector(string apiKey, string remoteUri = ProdutionUri, int maxConcurrentRequests = IcConstants.MaxConcurrentRequests, ILogger<InvisibleCollector> logger = null) : this(apiKey, new Uri(remoteUri), maxConcurrentRequests, logger)
+        public InvisibleCollector(string apiKey, string remoteUri = ProductionUri, int maxConcurrentRequests = IcConstants.MaxConcurrentRequests, ILogger<InvisibleCollector> logger = null) : this(apiKey, new Uri(remoteUri), maxConcurrentRequests, logger)
         {
         }
 

--- a/InvisibleCollectorLib/InvisibleCollector.cs
+++ b/InvisibleCollectorLib/InvisibleCollector.cs
@@ -42,27 +42,26 @@ namespace InvisibleCollectorLib
         /// <param name="apiKey">The company API Key</param>
         /// <param name="remoteUri">The InvisibleCollector service address.</param>
         /// <param name="logger">The logger to be used by the lib</param>
-        public InvisibleCollector(string apiKey, string remoteUri = ProdutionUri,
-            ILogger<InvisibleCollector> logger = null)
+        /// <param name="maxConcurrentRequests">The maximum number of concurrent HTTP requests to InvivisibleCollector</param>
+        public InvisibleCollector(string apiKey, string remoteUri = ProdutionUri, int maxConcurrentRequests = IcConstants.MaxConcurrentRequests, ILogger<InvisibleCollector> logger = null) : this(apiKey, new Uri(remoteUri), maxConcurrentRequests, logger)
         {
-            _uriBuilder = new HttpUriBuilder(remoteUri);
-            _jsonFacade = new JsonConvertFacade();
-            _apiFacade = new ApiConnectionFacade(apiKey, _jsonFacade.JsonStreamToStringDictionary);
-            _logger = logger ?? NullLogger<InvisibleCollector>.Instance;
-
-            _logger.LogInformation("Started Instance");
         }
 
         /// <summary>
         ///     Same as
         ///     <see
-        ///         cref="InvisibleCollector(string,string,Microsoft.Extensions.Logging.ILogger{InvisibleCollectorLib.InvisibleCollector})" />
+        ///         cref="InvisibleCollector(string,string,int,Microsoft.Extensions.Logging.ILogger{InvisibleCollectorLib.InvisibleCollector})" />
         ///     but the <paramref name="remoteUri" /> in Uri format.
         /// </summary>
         /// <param name="remoteUri">The Invisible Collector service address</param>
-        public InvisibleCollector(string apiKey, Uri remoteUri, ILogger<InvisibleCollector> logger = null) : this(
-            apiKey, remoteUri.AbsoluteUri, logger)
+        public InvisibleCollector(string apiKey, Uri remoteUri, int maxConcurrentRequests = IcConstants.MaxConcurrentRequests, ILogger<InvisibleCollector> logger = null)
         {
+            _uriBuilder = new HttpUriBuilder(remoteUri);
+            _jsonFacade = new JsonConvertFacade();
+            _apiFacade = new ApiConnectionFacade(apiKey, _jsonFacade.JsonStreamToStringDictionary, maxConcurrentRequests);
+            _logger = logger ?? NullLogger<InvisibleCollector>.Instance;
+
+            _logger.LogInformation("Started Instance");
         }
 
         /// <summary>

--- a/InvisibleCollectorLib/Utils/IcConstants.cs
+++ b/InvisibleCollectorLib/Utils/IcConstants.cs
@@ -4,5 +4,6 @@
     {
         internal const string JsonMimeType = "application/json";
         internal const string DateTimeFormat = "yyyy'-'MM'-'dd";
+        internal const int MaxConcurrentRequests = 90;
     }
 }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@
     only:
       - master
   version: 0.1.{build}
-  image: Visual Studio 2017
+  image: Visual Studio 2019
   environment:
     matrix:
       - configuration: Release
@@ -24,7 +24,7 @@
     only:
       - releases
   version: 0.2.{build}
-  image: Visual Studio 2017
+  image: Visual Studio 2019
   environment:
     matrix:
       - configuration: Release

--- a/test/Connection/ApiConnectionFacadeTest.cs
+++ b/test/Connection/ApiConnectionFacadeTest.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
-using System.Net;
+using System.Net.Http;
 using System.Threading.Tasks;
 using InvisibleCollectorLib.Connection;
 using InvisibleCollectorLib.Exception;
@@ -56,7 +56,7 @@ namespace test.Connection
         {
             _mockServer.AddRequest("GET", "unreachablPath")
                 .AddJsonResponse("", 200);
-            Assert.ThrowsAsync<WebException>(() =>
+            Assert.ThrowsAsync<HttpRequestException>(() =>
                 BuildApiFacade(EmptyDictionary)
                     .CallJsonToJsonApi(_mockServer.GetUrl(TestPath), "GET"));
         }
@@ -90,7 +90,7 @@ namespace test.Connection
         {
             _mockServer.AddRequest("GET", TestPath)
                 .AddJsonResponse("", 400);
-            Assert.ThrowsAsync<WebException>(() =>
+            Assert.ThrowsAsync<HttpRequestException>(() =>
                 BuildApiFacade(EmptyDictionary)
                     .CallJsonToJsonApi(_mockServer.GetUrl(TestPath), "GET"));
         }
@@ -100,7 +100,7 @@ namespace test.Connection
         {
             _mockServer.AddRequest("GET", TestPath)
                 .AddHtmlResponse("", 400); // supposed to fail here
-            Assert.ThrowsAsync<WebException>(() =>
+            Assert.ThrowsAsync<IcException>(() =>
                 BuildApiFacade(ErrorDictionary)
                     .CallJsonToJsonApi(_mockServer.GetUrl(TestPath), "GET"));
         }

--- a/test/InvisibleCollectorFunctional.cs
+++ b/test/InvisibleCollectorFunctional.cs
@@ -1,8 +1,8 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Net;
+using System.Net.Http;
 using System.Threading.Tasks;
 using InvisibleCollectorLib;
 using InvisibleCollectorLib.Model;
@@ -69,14 +69,14 @@ namespace test
         public void GetCompanyInfoAsync_fail404()
         {
             var ic = ConfigureIc("GET", "someunreachablepath", "{}");
-            Assert.ThrowsAsync<WebException>(() => ic.GetCompanyAsync());
+            Assert.ThrowsAsync<HttpRequestException>(() => ic.GetCompanyAsync());
         }
 
         [Test]
         public void GetCompanyInfoAsync_failRefuseConnection()
         {
             var uri = new Uri("http://localhost:56087"); //shouldn't be in use
-            Assert.ThrowsAsync<WebException>(() => new InvisibleCollector(TestApiKey, uri).GetCompanyAsync());
+            Assert.ThrowsAsync<HttpRequestException>(() => new InvisibleCollector(TestApiKey, uri).GetCompanyAsync());
         }
 
         [Test]

--- a/test/MockServerTesterBase.cs
+++ b/test/MockServerTesterBase.cs
@@ -12,7 +12,7 @@ namespace test
         protected const string TestApiKey = "12345";
 
         protected static readonly (string, string) ContentHeader = ("Content-Type", IcConstants.JsonMimeType);
-        protected static readonly (string, string) ContentHeaderEncoding = ("Content-Type", "charset=UTF-8");
+        protected static readonly (string, string) ContentHeaderEncoding = ("Content-Type", "charset=utf-8");
         protected static readonly (string, string) AcceptHeader = ("Accept", IcConstants.JsonMimeType);
         protected static readonly (string, string) AuthorizationHeader = ("Authorization", $"Bearer {TestApiKey}");
         protected static readonly (string, string) HostHeader = ("Host", "localhost");

--- a/test/test.csproj
+++ b/test/test.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
     </PropertyGroup>
     <ItemGroup>
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />


### PR DESCRIPTION
Implement HTTP concurrent connections limiting (set to 90, which is just a random number. a better number should be set in the future):
- Reimplement ApiConnectionFacade workings
- Update some tests and documentation

It's a breaking change because the exception class type thrown is now different.

Docs need regeneration

I have manually tested that rate limiting works